### PR TITLE
Update x86_64 crate version to fix compile errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ repository = "https://github.com/rust-osdev/ps2-mouse"
 
 [dependencies]
 bitflags = "1.2.1"
-x86_64 = "0.12.2"
+x86_64 = "0.13"


### PR DESCRIPTION
With rustc 1.52.0-nightly, currently this crate build fails:
```bash
--> /home/zg/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.12.4/src/lib.rs:9:43
  |
9 | #![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]
  |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ feature has been removed
  |
  = note: removed due to causing promotable bugs
```

Upgrade the dependency x86-64 crate version fixes it.